### PR TITLE
Make DefaultClientInformationExtractor compatible with official Apollo clients

### DIFF
--- a/src/DefaultClientInformationExtractor.php
+++ b/src/DefaultClientInformationExtractor.php
@@ -21,7 +21,7 @@ class DefaultClientInformationExtractor implements ClientInformationExtractor
 
     public function getClientName(): ?string
     {
-        return $this->request->headers->get('x-apollo-client-name');
+        return $this->request->headers->get('x-apollo-client-name', $this->request->headers->get('apollographql-client-name'));
     }
 
     public function getClientReferenceId(): ?string
@@ -31,6 +31,6 @@ class DefaultClientInformationExtractor implements ClientInformationExtractor
 
     public function getClientVersion(): ?string
     {
-        return $this->request->headers->get('x-apollo-client-version');
+        return $this->request->headers->get('x-apollo-client-version', $this->request->headers->get('apollographql-client-version'));
     }
 }


### PR DESCRIPTION
According to Apollo documentation, and official implementation of Apollo clients (iOS, web, Android), client information are sent to GraphQL server using `apollographql-client-name` and `apollographql-client-version` headers. 

This PR propose to accept these headers as fallback of `x-apollo-client-name` and `x-apollo-client-version` headers. to avoid need of writing custom `ClientInformationExtractor`.

Further reading :
- https://github.com/apollographql/apollo-ios/blob/7afcfc3c32950f7f6b6d768212f12412701ec7d6/Sources/Apollo/HTTPRequest.swift#L53-L54
- https://github.com/apollographql/apollo-client/blob/cbcf951256b22553bdb065dfa0d32c0a4ca804d3/src/link/http/createHttpLink.ts#L57-L60
- https://www.apollographql.com/docs/studio/client-awareness/#using-apollo-server-and-apollo-client

Backward compatibility:
- As new headers are used as fallback, this PR doesn't introduce breaking changes.