### PR TITLE
Improve command exit code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "google/protobuf": "^v3.13.0.1",
         "illuminate/redis": "^6.0 || ^7.0 || ^v8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^v8.0",
-        "nuwave/lighthouse": "^v4"
+        "nuwave/lighthouse": "^5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",

--- a/src/Actions/SendTracingToApollo.php
+++ b/src/Actions/SendTracingToApollo.php
@@ -53,7 +53,7 @@ class SendTracingToApollo
         // Convert tracings to map of query signature => traces.
         $tracesPerQuery = [];
         foreach ($this->tracing as $trace) {
-            $querySignature = $this->normalizeQuery($trace->queryText);
+            $querySignature = $this->normalizeQuery($trace->queryText, $trace->operationName);
             if (!isset($tracesPerQuery[$querySignature])) {
                 $tracesPerQuery[$querySignature] = [];
             }
@@ -107,11 +107,16 @@ class SendTracingToApollo
      * before the rest of the query.
      *
      * @param string $query
+     * @param string|null $operationName
      * @return string
      */
-    private function normalizeQuery(string $query): string
+    private function normalizeQuery(string $query, ?string $operationName): string
     {
         $trimmed = trim(preg_replace('/[\r\n\s]+/', ' ', $query));
+        if ($operationName !== null) {
+            return "# $operationName\n$trimmed";
+        }
+
         if (preg_match('/^(?:query|mutation) ([\w]+)/', $query, $matches)) {
             return "# ${matches[1]}\n$trimmed";
         }

--- a/src/Commands/SubmitTracing.php
+++ b/src/Commands/SubmitTracing.php
@@ -66,6 +66,7 @@ class SubmitTracing extends Command
      */
     public function handle(): void
     {
+        /** @var string $sendTracingMode */
         $sendTracingMode = $this->config->get('lighthouse-apollo.send_tracing_mode');
         switch ($sendTracingMode) {
             case 'sync':

--- a/src/Listeners/EndExecutionListener.php
+++ b/src/Listeners/EndExecutionListener.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BrightAlley\LighthouseApollo\Listeners;
+
+use BrightAlley\LighthouseApollo\QueryRequestStack;
+
+class EndExecutionListener
+{
+    private QueryRequestStack $requestStack;
+
+    public function __construct(QueryRequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function handle(): void
+    {
+        $this->requestStack->pop();
+    }
+}

--- a/src/Listeners/StartExecutionListener.php
+++ b/src/Listeners/StartExecutionListener.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BrightAlley\LighthouseApollo\Listeners;
+
+use BrightAlley\LighthouseApollo\QueryRequestStack;
+use Nuwave\Lighthouse\Events\StartExecution;
+
+class StartExecutionListener
+{
+    private QueryRequestStack $requestStack;
+
+    public function __construct(QueryRequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function handle(StartExecution $request): void
+    {
+        $this->requestStack->push($request);
+    }
+}

--- a/src/QueryRequestStack.php
+++ b/src/QueryRequestStack.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BrightAlley\LighthouseApollo;
+
+use Nuwave\Lighthouse\Events\StartExecution;
+
+class QueryRequestStack
+{
+    /**
+     * @var StartExecution[]
+     */
+    private array $stack = [];
+
+    public function push(StartExecution $execution): void
+    {
+        $this->stack[] = $execution;
+    }
+
+    public function pop(): ?StartExecution
+    {
+        return array_pop($this->stack);
+    }
+
+    public function current(): ?StartExecution
+    {
+        return end($this->stack);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,10 +5,14 @@ namespace BrightAlley\LighthouseApollo;
 use BrightAlley\LighthouseApollo\Commands\RegisterSchema;
 use BrightAlley\LighthouseApollo\Commands\SubmitTracing;
 use BrightAlley\LighthouseApollo\Contracts\ClientInformationExtractor;
+use BrightAlley\LighthouseApollo\Listeners\EndExecutionListener;
 use BrightAlley\LighthouseApollo\Listeners\ManipulateResultListener;
+use BrightAlley\LighthouseApollo\Listeners\StartExecutionListener;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Nuwave\Lighthouse\Events\EndExecution;
 use Nuwave\Lighthouse\Events\ManipulateResult;
+use Nuwave\Lighthouse\Events\StartExecution;
 use Nuwave\Lighthouse\Tracing\TracingServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
@@ -28,11 +32,14 @@ class ServiceProvider extends BaseServiceProvider
     public function register(): void
     {
         $this->app->register(TracingServiceProvider::class);
+        $this->app->singleton(QueryRequestStack::class);
         $this->app->bind(ClientInformationExtractor::class, DefaultClientInformationExtractor::class);
 
         $this->mergeConfigFrom(__DIR__ . '/../config/lighthouse-apollo.php', 'lighthouse-apollo');
 
+        Event::listen(StartExecution::class, StartExecutionListener::class);
         Event::listen(ManipulateResult::class, ManipulateResultListener::class);
+        Event::listen(EndExecution::class, EndExecutionListener::class);
     }
 
     private function bootForConsole(): void

--- a/src/TracingResult.php
+++ b/src/TracingResult.php
@@ -13,6 +13,8 @@ class TracingResult
 
     public ?array $variables;
 
+    public ?string $operationName;
+
     public array $client;
 
     public array $http;
@@ -47,6 +49,7 @@ class TracingResult
      *
      * @param string $queryText
      * @param array|null $variables
+     * @param string|null $operationName
      * @param array $client
      * @param array $http
      * @param array $tracing
@@ -55,6 +58,7 @@ class TracingResult
     public function __construct(
         string $queryText,
         ?array $variables,
+        ?string $operationName,
         array $client,
         array $http,
         array $tracing,
@@ -62,6 +66,7 @@ class TracingResult
     ) {
         $this->queryText = $queryText;
         $this->variables = $variables;
+        $this->operationName = $operationName;
         $this->client = $client;
         $this->http = $http;
         $this->tracing = $tracing;

--- a/tests/TracingResultTest.php
+++ b/tests/TracingResultTest.php
@@ -8,6 +8,7 @@ use BrightAlley\Tests\Support\QueryType;
 use Exception;
 use GraphQL\Error\Error;
 use GraphQL\Error\FormattedError;
+use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Schema;
@@ -54,9 +55,11 @@ class TracingResultTest extends TestCase
         $now = microtime(true);
         $tracing->record(
             new ResolveInfo(
-                'hello',
+                FieldDefinition::create([
+                    'name' => 'hello',
+                    'type' => new StringType(),
+                ]),
                 [],
-                new StringType(),
                 $queryType = new QueryType(),
                 ['hello'],
                 new Schema(['query' => $queryType]),
@@ -84,6 +87,7 @@ class TracingResultTest extends TestCase
         $tracing = new TracingResult(
             '{ hello }',
             null,
+            null,
             $this->sampleClientData(),
             $this->sampleHttpData(),
             $this->sampleTracingData(),
@@ -104,6 +108,7 @@ class TracingResultTest extends TestCase
         $tracing = new TracingResult(
             '{ hello }',
             ['key' => json_encode('value', JSON_THROW_ON_ERROR)],
+            null,
             $this->sampleClientData(),
             $this->sampleHttpData(),
             $this->sampleTracingData(),
@@ -135,6 +140,7 @@ class TracingResultTest extends TestCase
         $tracing = new TracingResult(
             '{ hello }',
             null,
+            null,
             array_merge($this->sampleClientData(), $clientData),
             $this->sampleHttpData(),
             $this->sampleTracingData(),
@@ -157,6 +163,7 @@ class TracingResultTest extends TestCase
         $tracing = new TracingResult(
             '{ hello }',
             null,
+            null,
             $this->sampleClientData(),
             $this->sampleHttpData(),
             $this->sampleTracingData(),
@@ -165,7 +172,7 @@ class TracingResultTest extends TestCase
                     'some error',
                     null,
                     null,
-                    null,
+                    [],
                     null,
                     new Exception('internal error message')
                 ),
@@ -191,6 +198,7 @@ class TracingResultTest extends TestCase
         $tracing = new TracingResult(
             '{ hello { world } }',
             null,
+            null,
             $this->sampleClientData(),
             $this->sampleHttpData(),
             $tracingData,
@@ -199,7 +207,7 @@ class TracingResultTest extends TestCase
                     'some error',
                     null,
                     null,
-                    null,
+                    [],
                     ['hello', 'world'],
                     new Exception('internal error message')
                 ),


### PR DESCRIPTION
With recent 500 errors from Apollo we discovered the command submit-tracing was exiting with a success (0) code even when Apollo backend was down. Because our distributed cron service is highly relying on command exit code, it took us time to notice those errors. 

Moreover, logs was displaying "All done!" even when an error occurred.

This PR aims to clarify command exit code and meaning of message "All done!".

It will be now 2 cases in which exit code won't be 0 :
- When tracing mode is not supported
- When an error occurs on request to Apollo.

Also "All done!" not displayed anymore when no pending tracings on Redis, as I presumed "all" was a reference to the tracings to send. And obviously not displayed neither when an error occurs.